### PR TITLE
Makes consts private to not pullute global namespace

### DIFF
--- a/LoadingShimmer/Classes/LoadingShimmer.swift
+++ b/LoadingShimmer/Classes/LoadingShimmer.swift
@@ -8,8 +8,8 @@
 
 import UIKit
 
-let kScreenHeight = UIScreen.main.bounds.size.height
-let safeAreaTopHeight = (kScreenHeight == 812.0 || kScreenHeight == 896.0) ? 88 : 64
+private let kScreenHeight = UIScreen.main.bounds.size.height
+private let safeAreaTopHeight = (kScreenHeight == 812.0 || kScreenHeight == 896.0) ? 88 : 64
 
 class LoadingShimmer: NSObject {
 


### PR DESCRIPTION
By the way, what are these special screen sizes 812.0 and  896.0 which calculation of safeAreaTopHeight is trying to work around?