### PR TITLE
Address issue #27, use target view's background color.

### DIFF
--- a/LoadingShimmer/Classes/LoadingShimmer.swift
+++ b/LoadingShimmer/Classes/LoadingShimmer.swift
@@ -22,7 +22,7 @@ public class LoadingShimmer: NSObject {
         if _viewCover == nil {
             _viewCover = UIView()
             _viewCover?.tag = 1024
-            _viewCover?.backgroundColor = UIColor.white
+            _viewCover?.backgroundColor = UIColor.clear
         }
         return _viewCover
     }
@@ -75,7 +75,7 @@ public class LoadingShimmer: NSObject {
             return
         }
 
-        view?.backgroundColor = UIColor.white
+        viewCover?.backgroundColor = view?.backgroundColor
 
         if (view?.subviews.count ?? 0) > 0 {
             for subview in view?.subviews ?? [] {
@@ -159,6 +159,13 @@ public class LoadingShimmer: NSObject {
         maskLayer.fillColor = UIColor.red.cgColor
 
         colorLayer.mask = maskLayer
+        
+        if let targetBackgroundColor = viewCover?.backgroundColor?.cgColor {
+            colorLayer.backgroundColor = targetBackgroundColor
+        } else {
+            colorLayer.backgroundColor = UIColor.white.cgColor
+        }
+        
         let animation = CABasicAnimation(keyPath: "locations")
         animation.fromValue = colorLayer.locations
         animation.toValue = [NSNumber(value: 0), NSNumber(value: 1), NSNumber(value: 1), NSNumber(value: 1.2), NSNumber(value: 1.2)]


### PR DESCRIPTION
This PR addresses [Issue #27](https://github.com/jogendra/LoadingShimmer/issues/27)

Changes:
_viewCover?.backgroundColor is now default clear.

It then gets assigned to the target view to cover background color
viewCover?.backgroundColor = view?.backgroundColor

The way the animation is taking place (colors with low alpha), we need to give the colorLayer a background color as to not expose the element that is being 'loaded'. Attempt to match the targetViews background color as well, otherwise fall back to white

Screenshot of the change: 

<img width="461" alt="Example of loading" src="https://user-images.githubusercontent.com/11654738/58716100-eb21d080-838d-11e9-99cb-2441fbcb5559.png">


@jogendra I did not want to over extend my boundaries so will leave podspec update / example project update to integrate this change in your hands.

Cheers

